### PR TITLE
Workaround for unmaintained Globalize bug

### DIFF
--- a/dist/husky.js
+++ b/dist/husky.js
@@ -46567,7 +46567,14 @@ define("datepicker-zh-TW", function(){});
                     if (!app.config.culture || !app.config.culture.name) {
                         return key;
                     }
-                    var translation = Globalize.localize(key, app.config.culture.name);
+
+                    try {
+                        var translation = Globalize.localize(key, app.config.culture.name);
+                    } catch (e) {
+                        app.logger.warn('Globalize threw an error when translating key "' + key + '", failling back to key. Error: ' + e);
+                        return key;
+                    }
+
                     return !!translation ? translation : key;
                 };
 

--- a/husky_extensions/globalize.js
+++ b/husky_extensions/globalize.js
@@ -48,7 +48,14 @@
                     if (!app.config.culture || !app.config.culture.name) {
                         return key;
                     }
-                    var translation = Globalize.localize(key, app.config.culture.name);
+
+                    try {
+                        var translation = Globalize.localize(key, app.config.culture.name);
+                    } catch (e) {
+                        app.logger.warn('Globalize threw an error when translating key "' + key + '", failling back to key. Error: ' + e);
+                        return key;
+                    }
+
                     return !!translation ? translation : key;
                 };
 


### PR DESCRIPTION
Globalize has a bug where it tries to access a property on a NULL
object. This patch wraps the call in a try / catch and falls back
to the key.
