### PR TITLE
Avoid undefined error when datagrid row has no ID

### DIFF
--- a/husky_components/datagrid/decorators/table-view.js
+++ b/husky_components/datagrid/decorators/table-view.js
@@ -1117,7 +1117,7 @@ define(function() {
             this.sandbox.dom.stopPropagation(event);
             var recordId = this.sandbox.dom.data(event.currentTarget, 'id');
             this.emitRowClickedEvent(event);
-            if (!!this.table.rows[recordId]) {
+            if (!!recordId && !!this.table.rows[recordId]) {
                 if (this.options.highlightSelected === true) {
                     this.uniqueHighlightRecord(recordId);
                 }


### PR DESCRIPTION
On the Categories list page, clicking on the edit icon in the datagrid caused an `undefined` error because the ID property is not set on the table row.
